### PR TITLE
Refactor : 그룹 내에 이미 유저가 존재하면 관련 Exception을 반환한다.

### DIFF
--- a/src/main/java/com/prography1/eruna/domain/repository/GroupUserRepository.java
+++ b/src/main/java/com/prography1/eruna/domain/repository/GroupUserRepository.java
@@ -23,4 +23,7 @@ public interface GroupUserRepository extends JpaRepository<GroupUser, GroupUser.
     Optional<GroupUser> findGroupUserByUser(User user);
 
     Optional<GroupUser> findByUser(User user);
+
+    boolean existsByGroupsAndUser(Groups group, User user);
+
 }

--- a/src/main/java/com/prography1/eruna/response/BaseResponseStatus.java
+++ b/src/main/java/com/prography1/eruna/response/BaseResponseStatus.java
@@ -26,6 +26,7 @@ public enum BaseResponseStatus {
     NOT_FOUND_GROUP(false,2007,"해당 그룹을 찾을 수 없습니다."),
     NOT_FOUND_GROUP_USER(false,2008,"해당 그룹멤버를 찾을 수 없습니다."),
     NOT_FOUND_ALARM(false, 2009, "해당 알람 정보를 찾을 수 없습니다."),
+    ALREADY_IN_GROUP_USER(false, 2010, "이미 그룹 내에 존재하는 유저입니다."),
 
 
 

--- a/src/main/java/com/prography1/eruna/service/GroupService.java
+++ b/src/main/java/com/prography1/eruna/service/GroupService.java
@@ -159,4 +159,11 @@ public class GroupService {
             throw new RuntimeException(e);
         }
     }
+
+    public boolean isUserExistInGroup(String uuid, String code){
+        User user = userRepository.findByUuid(uuid).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+        Groups group = groupRepository.findByCode(code).orElseThrow(() -> new BaseException(INVALID_GROUP_CODE));
+        return groupUserRepository.existsByGroupsAndUser(group, user);
+//        return userRepository.existsByUuid(uuid);
+    }
 }

--- a/src/main/java/com/prography1/eruna/web/GroupController.java
+++ b/src/main/java/com/prography1/eruna/web/GroupController.java
@@ -61,8 +61,11 @@ public class GroupController {
         if(!groupService.isValidCode(code)) throw new BaseException(BaseResponseStatus.INVALID_GROUP_CODE);
         String uuid = groupJoinUserInfo.getUuid();
         if(!userService.isUserExist(uuid)) throw new BaseException(BaseResponseStatus.INVALID_UUID_TOKEN);
+        if(groupService.isUserExistInGroup(uuid, code))
+            throw new BaseException(BaseResponseStatus.ALREADY_IN_GROUP_USER);
         String nickname = groupJoinUserInfo.getNickname();
         if(groupService.isDuplicatedNickname(code, nickname)) throw new BaseException(BaseResponseStatus.DUPLICATED_NICKNAME);
+
 
         groupService.joinGroupUser(code, uuid, nickname, groupJoinUserInfo.getPhoneNum());
         return new BaseResponse<>("ok");


### PR DESCRIPTION
JPA 에서 key값이 유니크하지않으면 JPA modifiedAt만 수정하는데, 여기서 createdAt이 null로 처리되어 createdAt cannot be null 에러가 발생한다.

relatedTo #44